### PR TITLE
Avoid no config file error

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Install terraform and run to create instances for tests
 ```
 $ brew install terraform
 $ env $(cat .env) terraform plan
-$ env ($cat .env) terraform apply
+$ env $(cat .env) terraform apply
 ```
 
 Run test

--- a/lib/ec2/host/config.rb
+++ b/lib/ec2/host/config.rb
@@ -129,7 +129,6 @@ class EC2
       def self.config
         return @config if @config
         @config = {}
-
         if File.exist?(config_file)
           File.readlines(config_file).each do |line|
             next if line.start_with?('#')

--- a/lib/ec2/host/config.rb
+++ b/lib/ec2/host/config.rb
@@ -129,10 +129,13 @@ class EC2
       def self.config
         return @config if @config
         @config = {}
-        File.readlines(config_file).each do |line|
-          next if line.start_with?('#')
-          key, val = line.chomp.split('=', 2)
-          @config[key] = val
+
+        if File.exist?(config_file)
+          File.readlines(config_file).each do |line|
+            next if line.start_with?('#')
+            key, val = line.chomp.split('=', 2)
+            @config[key] = val
+          end
         end
         @config
       end


### PR DESCRIPTION
While I was trying to run the following code:

```
require 'dotenv'
equire 'ec2-host'

host = EC2::Host.new(role: "foo")
host.each { |h| puts h }
```

I got this error though I set all of environment variables.

```
Errno::ENOENT: No such file or directory @ rb_sysopen - /etc/default/ec2-host
from /Users/bob/.rbenv/versions/2.4.1/gemsets/mojaco-infra/gems/ec2-host-0.5.7/lib/ec2/host/config.rb:133:in `readlines'
```

Because `config.fetch('AWS_REGION', nil)` is evaluated before `ENV['AWS_DEFAULT_REGION']` is evaluated at:

https://github.com/sonots/ec2-host/blob/master/lib/ec2/host/config.rb#L34-L36

and I put configuration file neither  '/etc/sysconfig/ec2-host, '/etc/sysconfig/ec2-host' nor '/etc/default/ec2-host'.

Thanks 🙇 
