### PR TITLE
Fix display_short_info conditions

### DIFF
--- a/lib/ec2/host/host_data.rb
+++ b/lib/ec2/host/host_data.rb
@@ -251,7 +251,7 @@ class EC2
       # show in short format, otherwise, same with to_hash.to_s
       def self.display_short_info?
         return @display_short_info unless @display_short_info.nil?
-        @display_short_info = method_defined?(:service) and method_defined?(:status) and method_defined?(:tags)
+        @display_short_info = (method_defined?(:service) and method_defined?(:status) and method_defined?(:tags))
       end
     end
   end


### PR DESCRIPTION
When settting only the `Service` tag or `Service` and `Status` tags, `display_short_info?`  returns true.

```
irb(main):001:0> @foo = true and true and true
=> true
irb(main):002:0> p @foo
true
=> true
irb(main):003:0> @foo = true and false and false
=> false
irb(main):005:0> p @foo
true
=> true
```