### PR TITLE
Fix Set Multi Role 

### DIFF
--- a/lib/ec2/host/host_data.rb
+++ b/lib/ec2/host/host_data.rb
@@ -211,7 +211,7 @@ class EC2
           parts = role.first.split(Config.role_tag_delimiter, Config.role_max_depth)
         else
           parts = 1.upto(Config.role_max_depth).map do |i|
-            (condition["role#{i}".to_sym] || condition["usage#{i}".to_sym] || []).first
+            (condition["role#{i}".to_sym] || condition["usage#{i}".to_sym] || nil)
           end
         end
         return true if parts.compact.empty? # no role conditions

--- a/lib/ec2/host/role_data.rb
+++ b/lib/ec2/host/role_data.rb
@@ -57,7 +57,7 @@ class EC2
       # @param [Array] role_parts such as ["admin", "jenkins", "slave"]
       def match?(*role_parts)
         indexes = role_parts.map.with_index {|part, i| part ? i : nil }.compact
-        @role_parts.values_at(*indexes) == role_parts.values_at(*indexes)
+        !(@role_parts.values_at(*indexes) & role_parts.values_at(*indexes).flatten).empty?
       end
 
       # Equality


### PR DESCRIPTION
ヘルプを見ると、roleは複数個設定できる。

```
$ ec2-host -h
Usage: ec2-host [options]
        --hostname one,two,three     name or private_dns_name
    -r, --role one,two,three         role
        --r1, --role1 one,two,three  role1, 1th part of role delimited by :
        --r2, --role2 one,two,three  role2, 2th part of role delimited by :
        --r3, --role3 one,two,three  role3, 3th part of role delimited by :
        --instance-id one,two,three  instance_id
        --state one,two,three        filter with instance state such as running, stopped (default: running)
        --monitoring one,two,three   filter with instance monitoring
        --[no-]spot                  filter to spot or non-spot instances
        --service one,two,three      service
        --status one,two,three       status
    -a, --all                        list all hosts (remove default filter)
        --private-ip, --ip           show private ip address instead of hostname
        --public-ip                  show public ip address instead of hostname
    -i, --info                       show host info
    -j, --jsonl                      show host info in line delimited json
        --json                       show host info in json
        --pretty-json                show host info in pretty json
        --debug                      debug mode
    -h, --help                       show help
    -v, --version                    show version
```

ただ、現状複数設定したうちの最初の要素のみしか検証していないので、その対応です。

