### PR TITLE
Fix to support multiple roles in one condition (or command line arguments)

### DIFF
--- a/lib/ec2/host/host_data.rb
+++ b/lib/ec2/host/host_data.rb
@@ -208,14 +208,18 @@ class EC2
       def role_match?(condition)
         # usage is an alias of role
         if role = (condition[:role] || condition[:usage])
-          parts = role.first.split(Config.role_tag_delimiter, Config.role_max_depth)
+          role.any? do |r|
+            parts = r.split(Config.role_tag_delimiter, Config.role_max_depth)
+            next true if parts.compact.empty? # no role conditions
+            roles.find {|role| role.match?(*parts) }
+          end
         else
           parts = 1.upto(Config.role_max_depth).map do |i|
-            (condition["role#{i}".to_sym] || condition["usage#{i}".to_sym] || []).first
+            condition["role#{i}".to_sym] || condition["usage#{i}".to_sym]
           end
+          return true if parts.compact.empty? # no role conditions
+          roles.find {|role| role.match?(*parts) }
         end
-        return true if parts.compact.empty? # no role conditions
-        roles.find {|role| role.match?(*parts) }
       end
 
       def instance_match?(condition)

--- a/lib/ec2/host/role_data.rb
+++ b/lib/ec2/host/role_data.rb
@@ -54,10 +54,18 @@ class EC2
       #     RoleData.new('admin', 'jenkins', 'slave').match?(nil, 'jenkins') #=> true
       #     RoleData.new('admin', 'jenkins', 'slave').match?(nil, nil, 'slave') #=> true
       #
+      #     RoleData.new('foo', 'a').match?(['foo', 'bar']) #=> true
+      #     RoleData.new('bar', 'a').match?(['foo', 'bar']) #=> true
+      #
+      #     RoleData.new('foo', 'a').match?(['foo', 'bar'], ['a', 'b']) #=> true
+      #     RoleData.new('foo', 'a').match?(['foo', 'bar'], ['a', 'b']) #=> true
+      #     RoleData.new('bar', 'b').match?(['foo', 'bar'], ['a', 'b']) #=> true
+      #     RoleData.new('bar', 'b').match?(['foo', 'bar'], ['a', 'b']) #=> true
+      #
       # @param [Array] role_parts such as ["admin", "jenkins", "slave"]
       def match?(*role_parts)
         indexes = role_parts.map.with_index {|part, i| part ? i : nil }.compact
-        @role_parts.values_at(*indexes) == role_parts.values_at(*indexes)
+        indexes.all? {|i| Array(role_parts[i]).include?(@role_parts[i]) }
       end
 
       # Equality

--- a/spec/host_data_spec.rb
+++ b/spec/host_data_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe EC2::Host::HostData do
+  describe '#role_match?' do
+    def host_with_role(role)
+      EC2::Host::HostData.new(Object.new).tap do |data|
+        roles = [EC2::Host::RoleData.build(role)]
+        data.instance_variable_set(:@roles, roles)
+      end
+    end
+
+    context 'with role' do
+      it do
+        expect(host_with_role('admin:jenkins:slave').send(:role_match?, role: ['admin'])).to be_truthy
+        expect(host_with_role('admin:jenkins:slave').send(:role_match?, role: ['admin:jenkins'])).to be_truthy
+        expect(host_with_role('admin:jenkins:slave').send(:role_match?, role: ['admin:jenkins:slave'])).to be_truthy
+
+        expect(host_with_role('foo:a').send(:role_match?, role: ['foo:a', 'bar:b'])).to be_truthy
+        expect(host_with_role('bar:a').send(:role_match?, role: ['foo:a', 'bar:b'])).to be_falsey
+        expect(host_with_role('foo:b').send(:role_match?, role: ['foo:a', 'bar:b'])).to be_falsey
+        expect(host_with_role('bar:b').send(:role_match?, role: ['foo:a', 'bar:b'])).to be_truthy
+      end
+    end
+
+    context 'with roleN' do
+      it do
+        expect(host_with_role('foo:a').send(:role_match?, role1: ['foo', 'bar'], role2: ['a', 'b'])).to be_truthy
+        expect(host_with_role('bar:a').send(:role_match?, role1: ['foo', 'bar'], role2: ['a', 'b'])).to be_truthy
+        expect(host_with_role('baz:a').send(:role_match?, role1: ['foo', 'bar'], role2: ['a', 'b'])).to be_falsey
+        expect(host_with_role('foo:b').send(:role_match?, role1: ['foo', 'bar'], role2: ['a', 'b'])).to be_truthy
+        expect(host_with_role('bar:b').send(:role_match?, role1: ['foo', 'bar'], role2: ['a', 'b'])).to be_truthy
+        expect(host_with_role('baz:b').send(:role_match?, role1: ['foo', 'bar'], role2: ['a', 'b'])).to be_falsey
+
+        expect(host_with_role('foo:a').send(:role_match?, role2: ['a', 'b'])).to be_truthy
+        expect(host_with_role('foo:b').send(:role_match?, role2: ['a', 'b'])).to be_truthy
+        expect(host_with_role('foo:c').send(:role_match?, role2: ['a', 'b'])).to be_falsey
+      end
+    end
+  end
+end

--- a/spec/role_data_spec.rb
+++ b/spec/role_data_spec.rb
@@ -29,12 +29,40 @@ describe EC2::Host::RoleData do
   end
 
   describe '#match?' do
-    let(:subject) { EC2::Host::RoleData.build('web:test') }
-    it do
-      expect(subject.match?('web')).to be_truthy
-      expect(subject.match?('web', 'test')).to be_truthy
-      expect(subject.match?('web', 'test', 'wrong')).to be_falsey
-      expect(subject.match?('web', 'wrong')).to be_falsey
+    context 'with single match' do
+      let(:subject) { EC2::Host::RoleData.build('admin:jenkins:slave') }
+
+      it do
+        expect(subject.match?('admin')).to be_truthy
+        expect(subject.match?('admin', 'jenkins')).to be_truthy
+        expect(subject.match?('admin', 'jenkins', 'slave')).to be_truthy
+        expect(subject.match?(nil, 'jenkins')).to be_truthy
+        expect(subject.match?(nil, nil, 'slave')).to be_truthy
+
+        expect(subject.match?('wrong')).to be_falsey
+        expect(subject.match?('admin', 'wrong')).to be_falsey
+        expect(subject.match?('admin', 'jenkins', 'wrong')).to be_falsey
+        expect(subject.match?(nil, 'wrong')).to be_falsey
+        expect(subject.match?(nil, nil, 'wrong')).to be_falsey
+      end
+    end
+
+
+    context 'with array match' do
+      it do
+        expect(EC2::Host::RoleData.build('foo:a').match?(['foo', 'bar'])).to be_truthy
+        expect(EC2::Host::RoleData.build('bar:a').match?(['foo', 'bar'])).to be_truthy
+        expect(EC2::Host::RoleData.build('baz:a').match?(['foo', 'bar'])).to be_falsey
+
+        expect(EC2::Host::RoleData.build('foo:a').match?(['foo', 'bar'], ['a', 'b'])).to be_truthy
+        expect(EC2::Host::RoleData.build('bar:a').match?(['foo', 'bar'], ['a', 'b'])).to be_truthy
+        expect(EC2::Host::RoleData.build('baz:a').match?(['foo', 'bar'], ['a', 'b'])).to be_falsey
+        expect(EC2::Host::RoleData.build('foo:b').match?(['foo', 'bar'], ['a', 'b'])).to be_truthy
+        expect(EC2::Host::RoleData.build('bar:b').match?(['foo', 'bar'], ['a', 'b'])).to be_truthy
+        expect(EC2::Host::RoleData.build('baz:b').match?(['foo', 'bar'], ['a', 'b'])).to be_falsey
+
+        expect(EC2::Host::RoleData.build('foo:a').match?(nil, ['a', 'b'])).to be_truthy
+      end
     end
   end
 end


### PR DESCRIPTION
Fix https://github.com/sonots/ec2-host/pull/9

### Specification

Assume that we have hosts like:

```
gu2272:active(argus:production:worker){analytics}
gu2274:active(argus:production:web){analytics}
gu3307:active(argus:staging){analytics}
gu2223:active(medjed:production:worker){analytics}
gw2005:active(medjed:production:web){analytics}
gw2016:active(medjed:staging){analytics}
gw2154:active(triglav:production:agent){analytics}
gw2160:active(triglav:production:web){analytics}
gw2158:active(triglav:staging){analytics}
```

ec2-host should behave as:

```
$ ec2-host --role argus:production,medjed:staging
gu2272:active(argus:production:worker){analytics}
gu2274:active(argus:production:web){analytics}
gw2016:active(medjed:staging){analytics}
```

```
$ ec2-host --role1 argus,medjed
gu2272:active(argus:production:worker){analytics}
gu2274:active(argus:production:web){analytics}
gu3307:active(argus:staging){analytics}
gu2223:active(medjed:production:worker){analytics}
gw2005:active(medjed:production:web){analytics}
gw2016:active(medjed:staging){analytics}
```

```
$ ec2-host --role1 argus,medjed --role2 staging
gu3307:active(argus:staging){analytics}
gw2016:active(medjed:staging){analytics}
```

```
$ ec2-host --role1 argus,medjed --role2 staging,production
gu2272:active(argus:production:worker){analytics}
gu2274:active(argus:production:web){analytics}
gu3307:active(argus:staging){analytics}
gu2223:active(medjed:production:worker){analytics}
gw2005:active(medjed:production:web){analytics}
gw2016:active(medjed:staging){analytics}
```

(as `role1 IN ('argus', 'medjed') AND role2 IN ('staging', 'production')` if we express in SQL)