### PR TITLE
Support assume role credential and instance profile.

### DIFF
--- a/ec2-host.gemspec
+++ b/ec2-host.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'aws-sdk-ec2'
   gem.add_runtime_dependency 'dotenv'
-  gem.add_runtime_dependency 'inifile'
+  gem.add_runtime_dependency 'aws_config'
 
   gem.add_development_dependency 'yard'
   gem.add_development_dependency 'rdoc'

--- a/lib/ec2/host/config.rb
+++ b/lib/ec2/host/config.rb
@@ -1,5 +1,5 @@
-require 'inifile'
 require 'dotenv'
+require 'aws_config'
 Dotenv.load
 
 class EC2
@@ -65,13 +65,10 @@ class EC2
 
       def self.aws_config
         return @aws_config if @aws_config
-        if File.readable?(aws_config_file)
-          ini = IniFile.load(aws_config_file).to_h
-          if aws_profile == 'default'
-            @aws_config = ini['default']
-          else
-            @aws_config = ini["profile #{aws_profile}"]
-          end
+        if File.readable?(aws_config_file) && File.readable?(aws_credential_file)
+          AWSConfig.config_file = aws_config_file
+          AWSConfig.credentials_file = aws_credential_file
+          @aws_config = AWSConfig[aws_profile]
         end
         @aws_config ||= {}
       end

--- a/lib/ec2/host/ec2_client.rb
+++ b/lib/ec2/host/ec2_client.rb
@@ -39,14 +39,14 @@ class EC2
         if Config.aws_access_key_id and Config.aws_secret_access_key
           Aws::Credentials.new(Config.aws_access_key_id, Config.aws_secret_access_key)
         else
-          config = Config.aws_config
-          if config[:role_arn]
+          aws_config = Config.aws_config
+          if aws_config[:role_arn]
             Aws::AssumeRoleCredentials.new(
-              client: Aws::STS::Client.new(config.config_hash),
-              role_arn: config[:role_arn],
+              client: Aws::STS::Client.new(aws_config.config_hash),
+              role_arn: aws_config[:role_arn],
               role_session_name: "ec2-host-session-#{Time.now.to_i}"
             )
-          elsif config[:credential_source] == "Ec2InstanceMetadata"
+          elsif aws_config[:credential_source] == "Ec2InstanceMetadata"
             Aws::InstanceProfileCredentials.new
           else
             Aws::SharedCredentials.new(

--- a/lib/ec2/host/ec2_client.rb
+++ b/lib/ec2/host/ec2_client.rb
@@ -43,11 +43,12 @@ class EC2
             profile_name: Config.aws_profile,
             path: Config.aws_credential_file
           )
-          profile = Aws.shared_config.instance_variable_get(:@parsed_config)[Config.aws_profile]
-          if profile['credential_source'] == 'Ec2InstanceMetadata'
+          config = Aws.shared_config.instance_variable_get(:@parsed_config)[Config.aws_profile]
+          credentials = Aws.shared_config.instance_variable_get(:@parsed_credentials)[Config.aws_profile]
+          if credentials['credential_source'] == 'Ec2InstanceMetadata'
             Aws::InstanceProfileCredentials.new
-          elsif profile['role_arn']
-            assume_role_credentials(shared_credentials, profile['role_arn'])
+          elsif config['role_arn']
+            assume_role_credentials(shared_credentials, config['role_arn'])
           else
             shared_credentials
           end

--- a/lib/ec2/host/ec2_client.rb
+++ b/lib/ec2/host/ec2_client.rb
@@ -46,6 +46,8 @@ class EC2
               role_arn: config[:role_arn],
               role_session_name: "ec2-host-session-#{Time.now.to_i}"
             )
+          elsif config[:credential_source] == "Ec2InstanceMetadata"
+            Aws::InstanceProfileCredentials.new
           else
             Aws::SharedCredentials.new(
               profile_name: Config.aws_profile,


### PR DESCRIPTION
I respond assume role credeential and instance profile.

Usage is as follow.(example)

## assume role

```
[default]
role_arn = arn:aws:iam::549338637798:role/assume-role-test
source_profile = default
region = ap-northeast-1
```

## instance profile

```
[default]
credential_source=Ec2InstanceMetadata
```
