### PR TITLE
fix not work assume role.

### DIFF
--- a/lib/ec2/host/ec2_client.rb
+++ b/lib/ec2/host/ec2_client.rb
@@ -55,7 +55,7 @@ class EC2
         if Config.aws_config['role_arn']
           # wrapped by assume role if necessary
           Aws::AssumeRoleCredentials.new(
-            client: Aws::STS::Client.new(raw_credentials),
+            client: Aws::STS::Client.new(region: Config.aws_region, credentials: raw_credentials),
             role_arn: Config.aws_config['role_arn'],
             role_session_name: "ec2-host-session-#{Time.now.to_i}"
           )


### PR DESCRIPTION
ref: https://github.com/sonots/ec2-host/pull/17


```
# ec2-host
Traceback (most recent call last):
	14: from /opt/aws-tools/bin/ec2-host:29:in `<main>'
	13: from /opt/aws-tools/bin/ec2-host:29:in `load'
	12: from /opt/aws-tools/vendor/bundle/ruby/2.5.0/gems/analytics-aws-tools-1.6.1/exe/ec2-host:11:in `<top (required)>'
	11: from /opt/aws-tools/vendor/bundle/ruby/2.5.0/gems/ec2-host-1.0.2/lib/ec2/host/cli.rb:110:in `run'
	10: from /opt/aws-tools/vendor/bundle/ruby/2.5.0/gems/ec2-host-1.0.2/lib/ec2/host/cli.rb:110:in `sort_by'
	 9: from /opt/aws-tools/vendor/bundle/ruby/2.5.0/gems/ec2-host-1.0.2/lib/ec2/host.rb:102:in `each'
      end
	 8: from /opt/aws-tools/vendor/bundle/ruby/2.5.0/gems/ec2-host-1.0.2/lib/ec2/host.rb:102:in `each'
	 7: from /opt/aws-tools/vendor/bundle/ruby/2.5.0/gems/ec2-host-1.0.2/lib/ec2/host.rb:103:in `block in each'
	 6: from /opt/aws-tools/vendor/bundle/ruby/2.5.0/gems/ec2-host-1.0.2/lib/ec2/host/ec2_client.rb:16:in `instances'
	 5: from /opt/aws-tools/vendor/bundle/ruby/2.5.0/gems/ec2-host-1.0.2/lib/ec2/host/ec2_client.rb:35:in `ec2'
	 4: from /opt/aws-tools/vendor/bundle/ruby/2.5.0/gems/ec2-host-1.0.2/lib/ec2/host/ec2_client.rb:58:in `credentials'
	 3: from /opt/aws-tools/vendor/bundle/ruby/2.5.0/gems/aws-sdk-core-3.46.0/lib/seahorse/client/base.rb:99:in `new'
	 2: from /opt/aws-tools/vendor/bundle/ruby/2.5.0/gems/aws-sdk-core-3.46.0/lib/aws-sdk-sts/client.rb:203:in `initialize'
	 1: from /opt/aws-tools/vendor/bundle/ruby/2.5.0/gems/aws-sdk-core-3.46.0/lib/seahorse/client/base.rb:19:in `initialize'
/opt/aws-tools/vendor/bundle/ruby/2.5.0/gems/aws-sdk-core-3.46.0/lib/seahorse/client/base.rb:62:in `build_config': undefined method `merge' for #<Aws::SharedCredentials:0x0000000002c59db8> (NoMethodError)
```