### PR TITLE
fix bug. IAM role does not work with some cases.

### DIFF
--- a/lib/ec2/host/config.rb
+++ b/lib/ec2/host/config.rb
@@ -80,6 +80,15 @@ class EC2
         @aws_config ||= {}
       end
 
+      def self.aws_credential
+        return @aws_credential if @aws_credential
+        if File.readable?(aws_credentials_file)
+          ini = IniFile.load(aws_credentials_file).to_h
+          @aws_credential = ini[aws_profile]
+        end
+        @aws_credential ||= {}
+      end
+
       def self.log_level
         @log_level ||= ENV['LOG_LEVEL'] || config.fetch('LOG_LEVEL', 'info')
       end

--- a/lib/ec2/host/ec2_client.rb
+++ b/lib/ec2/host/ec2_client.rb
@@ -40,7 +40,7 @@ class EC2
       end
 
       def raw_credentials
-        if Config.aws_config['credential_source'] == 'Ec2InstanceMetadata'
+        if Config.aws_credential['credential_source'] == 'Ec2InstanceMetadata' || Config.aws_credential.empty?
           Aws::InstanceProfileCredentials.new
         elsif Config.aws_access_key_id and Config.aws_secret_access_key
           Aws::Credentials.new(Config.aws_access_key_id, Config.aws_secret_access_key)


### PR DESCRIPTION
IAM role does work on following 2-cases

## case1.

`credential_source` in credentials file.(not in config)

$HOME/.aws/config

```bash
[default]
region = ap-northeast-1
```

$HOME/.aws/credentials

```bash
[default]
credential_source = Ec2InstanceMetadata
```

## case2.

multi profile case. No `default` profile in credentials. 

$HOME/.aws/config

```bash:
[default]
region = ap-northeast-1

[profile profile_1]
region = ap-northeast-1
```

$HOME/.aws/credentials

```bash
[profile_1]
aws_access_key_id = XXXXXXXXXXXXXXXXXXX
aws_secret_access_key = XXXXXXXXXXXXXXXXXXXXXXXXXXXX

```
